### PR TITLE
Exclude minimap icons from NauticusClassic

### DIFF
--- a/MBB.lua
+++ b/MBB.lua
@@ -79,7 +79,8 @@ MBB_Ignore = {
 	[39] = "poiMinimap",	-- QuestPointer
 	[40] = "MiniMapLFGFrame",    -- LFG
 	[41] = "PremadeFilter_MinimapButton",    -- PreMadeFilter
-	[42] = "QuestieFrame" -- Questie Fix
+	[42] = "QuestieFrame", -- Questie Fix
+	[43] = "NauticusClassicMiniIcon" -- NauticusClassic Fix
 };
 
 MBB_IgnoreSize = {


### PR DESCRIPTION
The minimap icons in NauticusClassic need to be excluded otherwise it causes issues/crashes in MBBClassic.

https://www.curseforge.com/wow/addons/nauticusclassic