### PR TITLE
captured buttons click fix

### DIFF
--- a/MBB.lua
+++ b/MBB.lua
@@ -7,8 +7,8 @@
 	Previous Authors: Tunhadil, Fixed by Pericles for patch 2.23 til 4.0, fixed by yossa for patch 4.0.1, updated for 4.2+ by karlsnyder
 	
 ]]
-
-MBB_Version = "1.2.0";
+local addonName, mbb = ...
+MBB_Version = GetAddOnMetadata(addonName,"Version");
 
 -- Setup some variable for debugging.
 MBB_DebugFlag = 0;
@@ -339,7 +339,7 @@ function MBB_PrepareButton(name)
 	
 	if( buttonframe ) then
 		if( buttonframe.RegisterForClicks ) then
-			buttonframe:RegisterForClicks("LeftButtonDown","RightButtonDown");
+			buttonframe:RegisterForClicks("AnyDown");
 		end
 		
 		buttonframe.isvisible = buttonframe:IsVisible();

--- a/MBB.toc
+++ b/MBB.toc
@@ -1,6 +1,6 @@
-## Interface: 20501
+## Interface: 20503
 ## Author: karlsnyder, vallantv
-## Version: 1.2.0
+## Version: 1.2.1
 ## Title: MinimapButtonBag
 ## X-Category: Map
 ## Notes: Cleans up minimap buttons and makes them accessible through a pop out menu!


### PR DESCRIPTION
expand click registration so addons using middle/4/5 mouse buttons do not break
update toc interface for latest bcc, increment addon version, stop hardcoding it in the lua file
closes #19